### PR TITLE
add cmd and args options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Options:
   -p, --port   port to listen on                              [default: 5757]
   -h, --host   host to bind to                                [default: "localhost"]
   --mount      path to mount routes on                        [default: "/webhook"]
-  --slack      full url of slack webhook for posting results
+  --slack      full url of slack webhook to post results
   --help       Show help
 ```
 
@@ -39,9 +39,23 @@ module.exports =
     { pattern: /jthoober/, event: '*', script: '/usr/local/bin/fortune' },
     { pattern: /request/, event: 'push', script: './example-script.sh', passargs: true },
     {
+      pattern: /reponame/,
+      event: 'push',
+      script: './example-script.js',
+      cmd: 'node',
+      args: [process.env, '-t 100']
+      // will result in `node ./example-script.js <repoName> <branchName> <env> -t 100`
+    },
+    {
       pattern: /issue/,
       event: 'issues',
       func: function(event, cb) { console.log('hi'); cb(); },
+    },
+    {
+      pattern: /manyissues/,
+      event: 'issues',
+      args: [process.env, 'cheddar']
+      func: function(event, env, cheese, cb) { console.log('hi'); cb(); },
     }
 ];
 ```
@@ -58,6 +72,8 @@ Valid rules options:
 * `script`: external executable to invoke on match
 * `passargs`: if set & truthy, repo name & branch are sent to executable
 * `logfile`: full path of file to log executable output to; unused for functions
+* `cmd`: the executable to run the script with; unused for functions. e.g. `node`
+* `args`: an array of additional args to pass to the script or function. If `parseargs` is `true` these args will come after the repo and branch names. If `func` is passed, these args will come after the event name.
 
 ## Endpoints
 

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -34,6 +34,8 @@ var Rule = module.exports = function Rule(opts)
     this.func     = opts.func;
     this.logfile  = opts.logfile;
     this.passargs = !!opts.passargs;
+    this.cmd      = opts.cmd;
+    this.args     = opts.args;
 
     this.logger = bole('rule:' + this.pattern + ':' + this.event);
 
@@ -77,7 +79,7 @@ Rule.prototype.execFunction = function(event)
     self.logger.info('calling function');
     self.running = true;
     self.emit('running');
-    self.func(event, function(err)
+    self.func.apply(null, [event].concat(self.args || []).concat([function(err)
     {
         self.running = false;
 
@@ -89,7 +91,7 @@ Rule.prototype.execFunction = function(event)
 
         self.logger.info('function complete');
         self.emit('complete');
-    });
+    }]));
 };
 
 Rule.prototype.exec = function(event)
@@ -110,9 +112,15 @@ Rule.prototype.exec = function(event)
     self.emit('running');
 
     var cmd = self.script;
+    // if we have a cmd defined, it's a prefix to the script
+    if (self.cmd)
+        cmd = self.cmd + ' ' + self.script;
+
     var branch = (event.payload.ref ? event.payload.ref.replace(/^refs\/heads\//, '') : '');
     if (self.passargs)
         cmd += ' '  + event.payload.repository.name + ' ' + branch;
+    if (self.args)
+        cmd += ' ' + self.args.join(' ');
 
     self.logger.info('starting execution; cmd=' + cmd);
 


### PR DESCRIPTION
- scripts can now be called with custom executables. e.g. `node` or `zsh`
- both `func` and `script` can accept additional args. As defined by the optional `args` option.

Also, this some how bumped test coverage by 1% :)
