### PR TITLE
adds missing commas to rules.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ module.exports =
     {
       pattern: /manyissues/,
       event: 'issues',
-      args: [process.env, 'cheddar']
-      func: function(event, env, cheese, cb) { console.log('hi'); cb(); },
+      args: [process.env, 'cheddar'],
+      func: function(event, env, cheese, cb) { console.log('hi'); cb(); }
     },
     {
       pattern: /customLoggers/,
       event: '*',
       // options to pass to bole.output
-      loggers: {level: 'debug', stream: myWritableStream}
+      loggers: {level: 'debug', stream: myWritableStream},
       func: function(event, cb){
         this.logger.info('hi');
         cb();


### PR DESCRIPTION
I was just fooling around with the project to see how it works and I ran into syntax issues because of the missing commas in the example rules.json. This change is not super important, but it might help others playing around with the project for the first time.